### PR TITLE
Poet::Mason instance() can return different instances based on the request

### DIFF
--- a/lib/Poet/Mason.pm
+++ b/lib/Poet/Mason.pm
@@ -42,7 +42,7 @@ method get_plugins ($class:) {
 method handle_psgi ($class: $psgi_env) {
     my $req      = $env->app_class('Plack::Request')->new($psgi_env);
     my $response = try {
-        my $interp = $env->app_class('Mason')->instance;
+        my $interp = $env->app_class('Mason')->instance($req);
         my $m = $interp->_make_request( req => $req );
         $m->run( $class->_psgi_comp_path($req),
             $class->_psgi_parameters($req) );


### PR DESCRIPTION
This small change allows a single Poet app to have multiple Mason instances inside.

This is useful to me on a site that has multiple skins, on the same codebase. This allows me to tweak the comp_root of the Mason instance based on the host of the request.
