### PR TITLE
Fixes RT#90970 Class::MOP::load_class deprecation warnings

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -68,6 +68,7 @@ URI                          = 0
 URI::Escape                  = 0
 Try::Tiny                    = 0
 YAML::XS                     = 0
+Class::Load                  = 0.20
 
 [Prereqs / RuntimeRecommends]
 Log::Log4perl               = 0

--- a/lib/Poet/Server.pm
+++ b/lib/Poet/Server.pm
@@ -1,7 +1,7 @@
 package Poet::Server;
 use Poet qw($conf $poet);
 use Method::Signatures::Simple;
-use Class::MOP;
+use Class::Load;
 use strict;
 use warnings;
 
@@ -41,7 +41,7 @@ my $loaded_startup_modules;
 method load_startup_modules () {
     return if $loaded_startup_modules++;
     foreach my $module ( @{ $conf->get_list('server.load_modules') } ) {
-        Class::MOP::load_class($module);
+        Class::Load::load_class($module);
     }
 }
 

--- a/lib/Poet/Tools.pm
+++ b/lib/Poet/Tools.pm
@@ -2,7 +2,7 @@
 #
 package Poet::Tools;
 use Carp;
-use Class::MOP;
+use Class::Load;
 use Config;
 use Fcntl qw( :DEFAULT :seek );
 use File::Basename;
@@ -32,7 +32,7 @@ sub can_load {
 
     my $result;
     try {
-        Class::MOP::load_class($class_name);
+        Class::Load::load_class($class_name);
         $result = 1;
     }
     catch {


### PR DESCRIPTION
This fixes RT#90970: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90970
